### PR TITLE
#7: Compile time import for transform (version 1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,27 @@ lazy val sparkCommons = (project in file("spark-commons"))
     (Compile / compile) := ((Compile / compile) dependsOn printSparkScalaVersion).value // printSparkScalaVersion is run with compile
   ).dependsOn(sparkCommonsTest)
 
+lazy val spark2Commons = (project in file("spark2-commons"))
+  .settings(
+      name := "spark2-commons",
+      libraryDependencies ++= sparkCommonslibraryDependencies(scalaVersion.value),
+      (Compile / compile) := ((Compile / compile) dependsOn printSparkScalaVersion).value // printSparkScalaVersion is run with compile
+  ).dependsOn(sparkCommonsTest, sparkCommons)
+
+//lazy val spark2Commons = (project in file("spark-commons"))
+//  .settings(
+//      name := "spark2-commons",
+//      libraryDependencies ++= sparkCommonslibraryDependencies(scalaVersion.value),
+//      (Compile / compile) := ((Compile / compile) dependsOn printSparkScalaVersion).value // printSparkScalaVersion is run with compile
+//  ).dependsOn(sparkCommonsTest)
+//
+//lazy val spark3Commons = (project in file("spark-commons"))
+//  .settings(
+//      name := "spark3-commons",
+//      libraryDependencies ++= sparkCommonslibraryDependencies(scalaVersion.value),
+//      (Compile / compile) := ((Compile / compile) dependsOn printSparkScalaVersion).value // printSparkScalaVersion is run with compile
+//  ).dependsOn(sparkCommonsTest)
+
 lazy val sparkCommonsTest = (project in file("spark-commons-test"))
   .settings(
     name := "spark-commons-test",

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/implicits/DataFrameImplicits.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/implicits/DataFrameImplicits.scala
@@ -18,9 +18,7 @@ package za.co.absa.spark.commons.implicits
 
 import java.io.ByteArrayOutputStream
 
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Column, DataFrame}
-import za.co.absa.spark.commons.implicits.StructTypeImplicits.DataFrameSelector
 
 object DataFrameImplicits {
 
@@ -84,17 +82,6 @@ object DataFrameImplicits {
      * @return Returns aligned and filtered utils
      */
     def alignSchema(selector: List[Column]): DataFrame = df.select(selector: _*)
-
-    /**
-     * Using utils selector from [[DataFrameSelector.getDataFrameSelector]] aligns the utils of a DataFrame to the selector for operations
-     * where utils order might be important (e.g. hashing the whole rows and using except)
-     *
-     * @param structType model structType for the alignment of df
-     * @return Returns aligned and filtered utils
-     */
-    def alignSchema(structType: StructType): DataFrame = {
-      alignSchema(structType.getDataFrameSelector())
-    }
   }
 
 }

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/implicits/StructTypeImplicits.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/implicits/StructTypeImplicits.scala
@@ -16,10 +16,7 @@
 
 package za.co.absa.spark.commons.implicits
 
-import org.apache.spark.sql.Column
-import org.apache.spark.sql.functions.{col, struct}
 import org.apache.spark.sql.types._
-import za.co.absa.spark.commons.adapters.HofsAdapter
 import za.co.absa.spark.commons.implicits.DataTypeImplicits.DataTypeEnhancements
 import za.co.absa.spark.commons.implicits.StructFieldImplicits.StructFieldEnhancements
 import za.co.absa.spark.commons.utils.SchemaUtils.{getAllArraySubPaths, isCommonSubPath}
@@ -30,42 +27,42 @@ import scala.util.Try
 
 object StructTypeImplicits {
 
-  implicit class DataFrameSelector(schema: StructType) extends HofsAdapter {
-    /**
-     * Returns data selector that can be used to align utils of a data frame. You can use [[alignSchema]].
-     *
-     * @return Sorted DF to conform to utils
-     */
-    def getDataFrameSelector(): List[Column] = {
-
-      def processArray(arrType: ArrayType, column: Column, name: String): Column = {
-        arrType.elementType match {
-          case arrType: ArrayType =>
-            transform(column, x => processArray(arrType, x, name)).as(name)
-          case nestedStructType: StructType =>
-            transform(column, x => struct(processStruct(nestedStructType, Some(x)): _*)).as(name)
-          case _ => column
-        }
-      }
-
-      def processStruct(curSchema: StructType, parent: Option[Column]): List[Column] = {
-        curSchema.foldRight(List.empty[Column])((field, acc) => {
-          val currentCol: Column = parent match {
-            case Some(x) => x.getField(field.name).as(field.name)
-            case None => col(field.name)
-          }
-          field.dataType match {
-            case arrType: ArrayType => processArray(arrType, currentCol, field.name) :: acc
-            case structType: StructType => struct(processStruct(structType, Some(currentCol)): _*).as(field.name) :: acc
-            case _ => currentCol :: acc
-          }
-        })
-      }
-
-      processStruct(schema, None)
-    }
-
-  }
+//  implicit class DataFrameSelector(schema: StructType) extends HofsAdapter {
+//    /**
+//     * Returns data selector that can be used to align utils of a data frame. You can use [[alignSchema]].
+//     *
+//     * @return Sorted DF to conform to utils
+//     */
+//    def getDataFrameSelector(): List[Column] = {
+//
+//      def processArray(arrType: ArrayType, column: Column, name: String): Column = {
+//        arrType.elementType match {
+//          case arrType: ArrayType =>
+//            transform(column, x => processArray(arrType, x, name)).as(name)
+//          case nestedStructType: StructType =>
+//            transform(column, x => struct(processStruct(nestedStructType, Some(x)): _*)).as(name)
+//          case _ => column
+//        }
+//      }
+//
+//      def processStruct(curSchema: StructType, parent: Option[Column]): List[Column] = {
+//        curSchema.foldRight(List.empty[Column])((field, acc) => {
+//          val currentCol: Column = parent match {
+//            case Some(x) => x.getField(field.name).as(field.name)
+//            case None => col(field.name)
+//          }
+//          field.dataType match {
+//            case arrType: ArrayType => processArray(arrType, currentCol, field.name) :: acc
+//            case structType: StructType => struct(processStruct(structType, Some(currentCol)): _*).as(field.name) :: acc
+//            case _ => currentCol :: acc
+//          }
+//        })
+//      }
+//
+//      processStruct(schema, None)
+//    }
+//
+//  }
 
   implicit class StructTypeEnhancements(val schema: StructType) {
     /**

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/implicits/DataFrameImplicitsTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/implicits/DataFrameImplicitsTest.scala
@@ -236,22 +236,23 @@ class DataFrameImplicitsTest extends AnyFunSuite with SparkTestBase with JsonTes
     assert(actualOutput == expectedOutput)
   }
 
-  test("order schemas for equal schemas") {
-    val dfA = spark.read.json(Seq(jsonA).toDS)
-    val dfC = spark.read.json(Seq(jsonC).toDS).select("legs", "id", "key")
-
-    val dfA2Aligned = dfC.alignSchema(dfA.schema)
-
-    assert(dfA.columns.toSeq == dfA2Aligned.columns.toSeq)
-    assert(dfA.select("key").columns.toSeq == dfA2Aligned.select("key").columns.toSeq)
-  }
-
-  test("throw an error for DataFrames with different schemas") {
-    val dfA = spark.read.json(Seq(jsonA).toDS)
-    val dfB = spark.read.json(Seq(jsonB).toDS)
-
-    assertThrows[AnalysisException]{
-      dfA.alignSchema(dfB.schema)
-    }
-  }
+  // TODO
+//  test("order schemas for equal schemas") {
+//    val dfA = spark.read.json(Seq(jsonA).toDS)
+//    val dfC = spark.read.json(Seq(jsonC).toDS).select("legs", "id", "key")
+//
+//    val dfA2Aligned = dfC.alignSchema(dfA.schema)
+//
+//    assert(dfA.columns.toSeq == dfA2Aligned.columns.toSeq)
+//    assert(dfA.select("key").columns.toSeq == dfA2Aligned.select("key").columns.toSeq)
+//  }
+//
+//  test("throw an error for DataFrames with different schemas") {
+//    val dfA = spark.read.json(Seq(jsonA).toDS)
+//    val dfB = spark.read.json(Seq(jsonB).toDS)
+//
+//    assertThrows[AnalysisException]{
+//      dfA.alignSchema(dfB.schema)
+//    }
+//  }
 }

--- a/spark2-commons/src/main/scala/za/co/absa/spark/commons/adapters/TransformAdapter.scala
+++ b/spark2-commons/src/main/scala/za/co/absa/spark/commons/adapters/TransformAdapter.scala
@@ -16,22 +16,15 @@
 
 package za.co.absa.spark.commons.adapters
 
-import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.Column
-import za.co.absa.commons.version.Version
-import za.co.absa.commons.version.Version.VersionStringInterpolator
 
-trait HofsAdapter {
+trait TransformAdapter {
 
   /**
    * For Spark versions prior 3.0.0, delegates to {{{hofs.transform()}}}
-   * Otherwise delegates to the native Spark method.
    */
   val transform: (Column, Column => Column) => Column = {
-    if (Version.asSemVer(SPARK_VERSION) < semver"3.0.0")
-        za.co.absa.spark.hofs.transform(_: Column, _: Column => Column)
-      else
-        org.apache.spark.sql.functions.transform(_: Column, _: Column => Column)
+    za.co.absa.spark.hofs.transform(_: Column, _: Column => Column)
   }
 
 }

--- a/spark2-commons/src/main/scala/za/co/absa/spark/commons/implicits/DataFrameImplicitsExtra.scala
+++ b/spark2-commons/src/main/scala/za/co/absa/spark/commons/implicits/DataFrameImplicitsExtra.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.commons.implicits
+
+import java.io.ByteArrayOutputStream
+
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.DataFrame
+import za.co.absa.spark.commons.implicits.StructTypeImplicitsExtra.DataFrameSelector
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.{DataFrameEnhancements => BasicDataFrameEnhancements}
+
+object DataFrameImplicitsExtra {
+
+  implicit class DataFrameEnhancements(df: DataFrame) extends BasicDataFrameEnhancements(df){
+    /**
+     * Using utils selector from [[DataFrameSelector.getDataFrameSelector]] aligns the utils of a DataFrame to the selector for operations
+     * where utils order might be important (e.g. hashing the whole rows and using except)
+     *
+     * @param structType model structType for the alignment of df
+     * @return Returns aligned and filtered utils
+     */
+    def alignSchema(structType: StructType): DataFrame = {
+      alignSchema(structType.getDataFrameSelector())
+    }
+  }
+
+}

--- a/spark2-commons/src/main/scala/za/co/absa/spark/commons/implicits/StructTypeImplicitsExtra.scala
+++ b/spark2-commons/src/main/scala/za/co/absa/spark/commons/implicits/StructTypeImplicitsExtra.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.commons.implicits
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.{col, struct}
+import org.apache.spark.sql.types._
+import za.co.absa.spark.commons.adapters.TransformAdapter
+import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancements
+
+object StructTypeImplicitsExtra {
+
+  implicit class DataFrameSelector(schema: StructType) extends StructTypeEnhancements(schema) with TransformAdapter {
+    /**
+     * Returns data selector that can be used to align utils of a data frame. You can use [[alignSchema]].
+     *
+     * @return Sorted DF to conform to utils
+     */
+    def getDataFrameSelector(): List[Column] = {
+
+      def processArray(arrType: ArrayType, column: Column, name: String): Column = {
+        arrType.elementType match {
+          case arrType: ArrayType =>
+            transform(column, x => processArray(arrType, x, name)).as(name)
+          case nestedStructType: StructType =>
+            transform(column, x => struct(processStruct(nestedStructType, Some(x)): _*)).as(name)
+          case _ => column
+        }
+      }
+
+      def processStruct(curSchema: StructType, parent: Option[Column]): List[Column] = {
+        curSchema.foldRight(List.empty[Column])((field, acc) => {
+          val currentCol: Column = parent match {
+            case Some(x) => x.getField(field.name).as(field.name)
+            case None => col(field.name)
+          }
+          field.dataType match {
+            case arrType: ArrayType => processArray(arrType, currentCol, field.name) :: acc
+            case structType: StructType => struct(processStruct(structType, Some(currentCol)): _*).as(field.name) :: acc
+            case _ => currentCol :: acc
+          }
+        })
+      }
+
+      processStruct(schema, None)
+    }
+
+  }
+
+}

--- a/spark2-commons/src/test/scala/za/co/absa/spark/commons/implicits/DataFrameImplicitsExtraTest.scala
+++ b/spark2-commons/src/test/scala/za/co/absa/spark/commons/implicits/DataFrameImplicitsExtraTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.commons.implicits
+
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.{AnalysisException, DataFrame}
+import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.spark.commons.test.SparkTestBase
+
+class DataFrameImplicitsExtraTest extends AnyFunSuite with SparkTestBase with JsonTestData {
+  import spark.implicits._
+
+  import za.co.absa.spark.commons.implicits.DataFrameImplicitsExtra.DataFrameEnhancements
+
+  test("order schemas for equal schemas") {
+    val dfA = spark.read.json(Seq(jsonA).toDS)
+    val dfC = spark.read.json(Seq(jsonC).toDS).select("legs", "id", "key")
+
+    val dfA2Aligned = dfC.alignSchema(dfA.schema)
+
+    assert(dfA.columns.toSeq == dfA2Aligned.columns.toSeq)
+    assert(dfA.select("key").columns.toSeq == dfA2Aligned.select("key").columns.toSeq)
+  }
+
+  test("throw an error for DataFrames with different schemas") {
+    val dfA = spark.read.json(Seq(jsonA).toDS)
+    val dfB = spark.read.json(Seq(jsonB).toDS)
+
+    assertThrows[AnalysisException]{
+      dfA.alignSchema(dfB.schema)
+    }
+  }
+}

--- a/spark2-commons/src/test/scala/za/co/absa/spark/commons/implicits/StructTypeImplicitsExtraTest.scala
+++ b/spark2-commons/src/test/scala/za/co/absa/spark/commons/implicits/StructTypeImplicitsExtraTest.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.commons.implicits
+
+import org.apache.spark.sql.types._
+import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancements
+import za.co.absa.spark.commons.test.SparkTestBase
+
+class StructTypeImplicitsExtraTest extends AnyFunSuite with SparkTestBase with JsonTestData {
+
+}


### PR DESCRIPTION
* Majority of the implicit classes are created in the common part. Spark specific enhancements are in extra implicits inheriting the original ones.