### PR TITLE
#51: Spark-commons should depend on Spark-commons-test only in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val `sparkCommons` = (projectMatrix in file("spark-commons"))
   .settings(commonSettings: _*)
   .sparkRow(SparkVersionAxis(spark2), scalaVersions = Seq(scala211, scala212))
   .sparkRow(SparkVersionAxis(spark3), scalaVersions = Seq(scala212))
-  .dependsOn(sparkCommonsTest)
+  .dependsOn(sparkCommonsTest % "test")
 
 lazy val sparkCommonsTest = (projectMatrix in file("spark-commons-test"))
   .settings(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.3.0"
+ThisBuild / version := "0.3.1-SNAPSHOT"


### PR DESCRIPTION
* dependency only for test
* updated project version

Closes #51 