### PR TITLE
#59 fixing typo in homepage attribute

### DIFF
--- a/publish.sbt
+++ b/publish.sbt
@@ -56,7 +56,7 @@ ThisBuild / developers := List(
   )
 )
 
-ThisBuild / homepage := Some(url("https://github.com/AbsaOSS/spark-commomns"))
+ThisBuild / homepage := Some(url("https://github.com/AbsaOSS/spark-commons"))
 ThisBuild / description := "Spark Common Utilities for ABSA"
 
 // licenceHeader check:


### PR DESCRIPTION
I've noticed it just now, whilst looking for something in Maven Search.

Closes #59