### PR TITLE
#61: Implement stripPathFromFieldName

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,32 @@ A trait that brings Spark version independent implementation of `transform` func
 
 _SchemaUtils_ provides methods for working with schemas, its comparison and alignment.  
 
-1. Returns the parent path of a field. Returns an empty string if a root level field name is provided.
+1. Extracts the parent path of a field. Returns an empty string if a root level column name is provided.
 
     ```scala
       SchemaUtils.getParentPath(columnName)
     ```
 
-2. Get paths for all array subfields of this given datatype
+2. Extracts the field name of a fully qualified column name.
+
+    ```scala
+      SchemaUtils.stripParentPath(columnName)
+    ```
+
+
+3. Get paths for all array subfields of this given datatype.
 
     ```scala
       SchemaUtils.getAllArraySubPaths(other)
     ```
 
-3. For a given list of field paths determines if any path pair is a subset of one another.
+4. For a given list of field paths determines if any path pair is a subset of one another.
 
     ```scala
       SchemaUtils.isCommonSubPath(paths)
     ```
 
-4. Append a new attribute to path or empty string.
+5. Append a new attribute to path or empty string.
 
     ```scala
       SchemaUtils.appendPath(path, fieldName)

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/utils/SchemaUtils.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/utils/SchemaUtils.scala
@@ -21,18 +21,25 @@ import org.apache.spark.sql.types._
 object SchemaUtils {
 
   /**
-   * Returns the parent path of a field. Returns an empty string if a root level field name is provided.
+   * Extracts the parent path of a field. Returns an empty string if a root level column name is provided.
    *
    * @param columnName A fully qualified column name
    * @return The parent column name or an empty string if the input column is a root level column
    */
   def getParentPath(columnName: String): String = {
-    val index = columnName.lastIndexOf('.')
-    if (index > 0) {
-      columnName.substring(0, index)
-    } else {
-      ""
-    }
+    //using a sub-function might be tiny bit less efficient, as it generates both part, but it ensures consistency
+    columnPathAndCore(columnName)._1
+  }
+
+  /**
+   * Extracts the field name of a fully qualified column name.
+   *
+   * @param columnName A fully qualified column name
+   * @return The field name without the partent path or the whole string if the input column is a root level column
+   */
+  def stripParentPath(columnName: String): String = {
+    //using a sub-function might be tiny bit less efficient, as it generates both part, but it ensures consistency
+    columnPathAndCore(columnName)._2
   }
 
   /**
@@ -93,4 +100,13 @@ object SchemaUtils {
     }
   }
 
+  private def columnPathAndCore(columnName: String): (String, String) = {
+    val index = columnName.lastIndexOf('.')
+    if (index >= 0) {
+      (columnName.take(index), columnName.drop((index + 1)))
+    } else {
+      ("", columnName)
+    }
+
+  }
 }

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/utils/SchemaUtils.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/utils/SchemaUtils.scala
@@ -35,7 +35,7 @@ object SchemaUtils {
    * Extracts the field name of a fully qualified column name.
    *
    * @param columnName A fully qualified column name
-   * @return The field name without the partent path or the whole string if the input column is a root level column
+   * @return The field name without the parent path or the whole string if the input column is a root level column
    */
   def stripParentPath(columnName: String): String = {
     //using a sub-function might be tiny bit less efficient, as it generates both part, but it ensures consistency

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/utils/SchemaUtilsTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/utils/SchemaUtilsTest.scala
@@ -21,19 +21,29 @@ import org.scalatest.matchers.should.Matchers
 import za.co.absa.spark.commons.utils.SchemaUtils._
 
 class SchemaUtilsTest extends AnyFunSuite with Matchers {
-  // scalastyle:off magic.number
 
-  test("Test isCommonSubPath()") {
+  test("Test getParentPath") {
+    assertResult("a.b.c.d")(getParentPath("a.b.c.d.e"))
+    assertResult("")(getParentPath("a"))
+    assertResult("a")(getParentPath("a.bcd"))
+    assertResult("")(getParentPath(""))
+    assertResult("")(getParentPath("."))
+  }
+
+  test("Test stripParentPath") {
+    assertResult("e")(stripParentPath("a.b.c.d.e"))
+    assertResult("a")(stripParentPath("a"))
+    assertResult("bcd")(stripParentPath("a.bcd"))
+    assertResult("")(stripParentPath(""))
+    assertResult("")(stripParentPath("."))
+  }
+
+
+  test("Test isCommonSubPath") {
     assert (isCommonSubPath())
     assert (isCommonSubPath("a"))
     assert (isCommonSubPath("a.b.c.d.e.f", "a.b.c.d", "a.b.c", "a.b", "a"))
     assert (!isCommonSubPath("a.b.c.d.e.f", "a.b.c.x", "a.b.c", "a.b", "a"))
   }
 
-  test("Test getParentPath") {
-    assertResult(getParentPath("a.b.c.d.e"))("a.b.c.d")
-    assertResult(getParentPath("a"))("")
-    assertResult(getParentPath("a.bcd"))("a")
-    assertResult(getParentPath(""))("")
-  }
 }


### PR DESCRIPTION
* `stripPathFromFieldName` implemented under name `stripParentPath` for more consistency
* `SchemaUtilsTest` enhanced and fixed order of arguments in `assertResult` call

Closes #61 