### PR TITLE
#67: Make it easy to avoid repeated UDF registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,15 @@ Checking for 3.X versions
 SparkVersionGuard.fromSpark3XCompatibilitySettings.ensureSparkVersionCompatibility(SPARK_VERSION)
 ```
 
+### OncePerSparkSession
+
+Abstract class to help attach/register UDFs and similar object only once to a spark session.
+
+_Usage:+ extend this abstract class and implement the method [`register`]. On initialization the `register` method gets 
+executed only if the class + spark session combination is unique. 
+
+This way we ensure only single registration per spark session.
+
 ### DataFrameImplicits
 _DataFrameImplicits_ provides methods for transformations on Dataframes  
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,8 @@ SparkVersionGuard.fromSpark3XCompatibilitySettings.ensureSparkVersionCompatibili
 
 Abstract class to help attach/register UDFs and similar object only once to a spark session.
 
-_Usage:+ extend this abstract class and implement the method [`register`]. On initialization the `register` method gets 
+
+_Usage:_ Extend this abstract class and implement the method `register`. On initialization the `register` method gets 
 executed only if the class + spark session combination is unique. 
 
 This way we ensure only single registration per spark session.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ABSA Group Limited
+ * Copyright 2021 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,8 @@ object Dependencies {
   }
 
   def commonDependencies: Seq[ModuleID] = Seq(
-    "org.scalatest"         %% "scalatest"   % "3.1.0"      % Test
+    "org.scalatest"         %% "scalatest"     % "3.2.2"      % Test,
+    "org.mockito"           %% "mockito-scala" % "1.17.12"    % Test
   )
 
   def sparkDependencies(sparkVersion: String): Seq[ModuleID] = Seq(

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
@@ -4,6 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.commons
+
+import org.apache.spark.sql.SparkSession
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Abstract class to help attach/register UDFs and similar object only once to a spark session.
+ * This is done by using the companion object's registry [[ConcurrentHashMap]] that holds already
+ * instantiated classes thus not running the method [[register]] again on them.
+ *
+ * Usage: extend this abstract class and implement the method [[register]]. On initialization the
+ * [[register]] method gets called by the [[registerMe]] method if the class + spark session
+ * combination is unique. If it is not unique [[register]] will not get called again.
+ * This way we ensure only single registration per spark session.
+ *
+ * @param sparkToRegisterTo Spark session to which we wish to attach objects
+ */
+abstract class OncePerSparkSession()(implicit sparkToRegisterTo: SparkSession) extends Serializable {
+
+  protected def register(implicit spark: SparkSession): Unit
+
+  OncePerSparkSession.registerMe(this, sparkToRegisterTo)
+}
+
+object OncePerSparkSession {
+  private[this] type Key = (Int, String)
+
+  private[this] val registry = new ConcurrentHashMap[Key, Unit]
+
+  private[this] def makeKey(library: OncePerSparkSession, spark: SparkSession): Key = {
+    (
+      spark.hashCode(),  //using hash as sufficiently unique and allowing garbage collection
+      library.getClass.getName
+    )
+  }
+
+  private def registerMe(library: OncePerSparkSession, spark: SparkSession): Unit = {
+    Option(registry.putIfAbsent(makeKey(library, spark), Unit))
+      .getOrElse(library.register(spark))
+  }
+}

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -4,6 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.commons
+
+import org.apache.spark.sql.SparkSession
+import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.spark.commons.test.SparkTestBase
+import org.mockito.MockitoSugar
+
+class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTestBase {
+  test("Each library is registered only once and exactly once per Spark session") {
+    var libraryAInitCounter = 0
+    var libraryBInitCounter = 0
+
+    val anotherSpark: SparkSession =  mock[SparkSession]
+    class UDFLibraryA()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession()(sparkToRegisterTo) {
+      override protected def register(implicit spark: SparkSession): Unit = {
+        libraryAInitCounter += 1
+      }
+    }
+
+    class UDFLibraryB()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession()(sparkToRegisterTo) {
+      override protected def register(implicit spark: SparkSession): Unit = {
+        libraryBInitCounter += 1
+      }
+    }
+
+
+    new UDFLibraryA()
+    new UDFLibraryA()
+    new UDFLibraryB()
+    new UDFLibraryB()(anotherSpark)
+    assert(libraryAInitCounter == 1)
+    assert(libraryBInitCounter == 2)
+  }
+
+}


### PR DESCRIPTION
* `OncePerSparkSession` class implementation
* increased version of used scalatest from 3.1.0 to 3.2.2
* added dependency on mockito-scala 1.17.12

Closes #67 