### PR TITLE
#71: Publish fails on scaladoc generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
         with:
           java-version: "adopt@1.8"
       - name: Build and run tests
-        run: sbt test
+        run: sbt test doc

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
@@ -22,11 +22,11 @@ import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Abstract class to help attach/register UDFs and similar object only once to a spark session.
- * This is done by using the companion object's registry [[ConcurrentHashMap]] that holds already
+ * This is done by using the companion object's registry `ConcurrentHashMap` that holds already
  * instantiated classes thus not running the method [[register]] again on them.
  *
  * Usage: extend this abstract class and implement the method [[register]]. On initialization the
- * [[register]] method gets called by the [[registerMe]] method if the class + spark session
+ * [[register]] method gets called by the [[za.co.absa.spark.commons.OncePerSparkSession$.registerMe]] method if the class + spark session
  * combination is unique. If it is not unique [[register]] will not get called again.
  * This way we ensure only single registration per spark session.
  *
@@ -51,7 +51,8 @@ object OncePerSparkSession {
     )
   }
 
-  private def registerMe(library: OncePerSparkSession, spark: SparkSession): Unit = {
+  protected def registerMe(library: OncePerSparkSession, spark: SparkSession): Unit = {
+    // the function is `protected` to make it visible to `ScalaDoc`
     Option(registry.putIfAbsent(makeKey(library, spark), Unit))
       .getOrElse(library.register(spark))
   }

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/sql/functions.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/sql/functions.scala
@@ -27,7 +27,7 @@ object functions {
 // scalastyle:on
 
   /**
-   *  Similarly to [[col]] function evaluates the column based on the provided column name. But here, it can be a full
+   *  Similarly to `col` function evaluates the column based on the provided column name. But here, it can be a full
    *  path even of nested fields. It also evaluates arrays and maps where the array index or map key is in brackets `[]`.
    *
    * @param fullColName The full name of the column, where segments are separated by dots and array indexes or map keys


### PR DESCRIPTION
* removed failing `ScalaDoc` class references
* added check of documentation generation into the `build.yml` action

Fixes #71 