### PR TITLE
#78: Move ErrorMessage type from spark data standardization into spar…

### DIFF
--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/errorhandling/ErrorMessage.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/errorhandling/ErrorMessage.scala
@@ -1,17 +1,18 @@
 /*
-* Copyright 2022 ABSA Group Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package za.co.absa.spark.commons.errorhandling
 

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/errorhandling/ErrorMessage.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/errorhandling/ErrorMessage.scala
@@ -1,0 +1,53 @@
+/*
+* Copyright 2022 ABSA Group Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package za.co.absa.spark.commons.errorhandling
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.StructType
+import za.co.absa.spark.commons.errorhandling.ErrorMessage.Mapping
+
+/**
+ * Case class to represent an error message
+ *
+ * @param errType - Type or source of the error
+ * @param errCode - Internal error code
+ * @param errMsg - Textual description of the error
+ * @param errCol - The name of the column where the error occurred
+ * @param rawValues - Sequence of raw values (which are the potential culprits of the error)
+ * @param mappings - Sequence of Mappings i.e Mapping Table Column -> Equivalent Mapped Dataset column
+ */
+case class ErrorMessage(
+                         errType: String,
+                         errCode: String,
+                         errMsg: String,
+                         errCol: String,
+                         rawValues: Seq[String],
+                         mappings: Seq[Mapping] = Seq()
+                       )
+
+object ErrorMessage {
+  case class Mapping(
+                      mappingTableColumn: String,
+                      mappedDatasetColumn: String
+                    )
+
+  val errorColumnName = "errCol"
+  def errorColSchema(implicit spark: SparkSession): StructType = {
+    import spark.implicits._
+    spark.emptyDataset[ErrorMessage].schema
+  }
+}
+

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/errorhandling/ErrorMessageTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/errorhandling/ErrorMessageTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.commons.errorhandling
+
+import org.apache.spark.sql.types.{ArrayType, StringType, StructField, StructType}
+import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.spark.commons.test.SparkTestBase
+
+class ErrorMessageTest extends AnyFunSuite with SparkTestBase {
+  test("errorColSchema returns the expected structure"){
+    val expected = StructType(Seq(
+      StructField("errType", StringType, nullable = true),
+      StructField("errCode", StringType, nullable = true),
+      StructField("errMsg", StringType, nullable = true),
+      StructField("errCol", StringType, nullable = true),
+      StructField("rawValues", ArrayType(StringType, containsNull = true), nullable = true),
+      StructField("mappings", ArrayType(
+        StructType(Seq(
+          StructField("mappingTableColumn", StringType, nullable = true),
+          StructField("mappedDatasetColumn", StringType, nullable = true)
+        )), containsNull = true),
+        nullable = true)
+    ))
+
+    val result = ErrorMessage.errorColSchema
+    assert(result == expected)
+  }
+}


### PR DESCRIPTION
…k commons

* Created ErrorMessage class based on standardization library one
* Created unit test for ErrorMessage class

Closes #78