### PR TITLE
alter once per spark session to be instantiatable even without provided spark session: 82

### DIFF
--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
@@ -17,7 +17,6 @@
 package za.co.absa.spark.commons
 
 import org.apache.spark.sql.SparkSession
-
 import java.util.concurrent.ConcurrentHashMap
 
 /**

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
@@ -41,9 +41,9 @@ abstract class OncePerSparkSession() extends Serializable {
   }
 
   def register(implicit spark: SparkSession): Boolean = {
-    val created = OncePerSparkSession.registerMe(this, spark)
+    val registered = OncePerSparkSession.registerMe(this, spark)
 
-    if (created == this) true
+    if (registered == this) true
     else false
   }
 

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
@@ -17,7 +17,6 @@
 package za.co.absa.spark.commons
 
 import org.apache.spark.sql.SparkSession
-import org.fusesource.hawtjni.runtime.Library
 
 import java.util.concurrent.ConcurrentHashMap
 

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/OncePerSparkSession.scala
@@ -39,8 +39,12 @@ abstract class OncePerSparkSession() extends Serializable {
     this()
     register(sparkToRegisterTo)
   }
-  def register(implicit spark: SparkSession): Unit = {
-    OncePerSparkSession.registerMe(this, spark)
+
+  def register(implicit spark: SparkSession): Boolean = {
+    val created = OncePerSparkSession.registerMe(this, spark)
+
+    if (created == this) true
+    else false
   }
 
   protected def registerBody(spark: SparkSession): Unit

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/sql/functions.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/sql/functions.scala
@@ -18,6 +18,7 @@ package za.co.absa.spark.commons.sql
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.col
+//import za.co.absa.spark.commons.utils.SchemaUtils
 import za.co.absa.spark.commons.utils.SchemaUtils
 
 import scala.util.{Success, Try}

--- a/spark-commons/src/main/scala/za/co/absa/spark/commons/sql/functions.scala
+++ b/spark-commons/src/main/scala/za/co/absa/spark/commons/sql/functions.scala
@@ -18,7 +18,6 @@ package za.co.absa.spark.commons.sql
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.col
-//import za.co.absa.spark.commons.utils.SchemaUtils
 import za.co.absa.spark.commons.utils.SchemaUtils
 
 import scala.util.{Success, Try}

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -48,7 +48,7 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
     assert(libraryBInitCounter == 2)
   }
 
-  test("should return true if the library is registered successfully and false if not"){
+  test("should return true if the library is registered successfully and false if not and if spark is not hasn't started"){
     var libraryAInitCounter = 0
     var results_1 = false
     var results_2 = false
@@ -63,6 +63,27 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
     new UDFLibrary()
     assert(results_1 == true)
     assert(results_2 == false)
+  }
+
+  test("should return is registered successfully and false if not and if spark is not hasn't started") {
+    var libraryAInitCounter = 0
+//    var results_1 = false
+//    var results_2 = false
+
+    val anotherSpark: SparkSession =  mock[SparkSession]
+    class UDFLibrary()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession(sparkToRegisterTo) {
+      val results_1 = this.register(sparkToRegisterTo)
+      val results_2 = this.register(sparkToRegisterTo)
+
+      override protected def registerBody(spark: SparkSession): Unit = {
+        libraryAInitCounter += 1
+      }
+    }
+
+//    new UDFLibrary()
+    val results = new UDFLibrary()(anotherSpark)
+    assert(results.results_1 == true)
+    assert(results.results_2 == false)
   }
 
 }

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -27,14 +27,15 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
     var libraryBInitCounter = 0
 
     val anotherSpark: SparkSession =  mock[SparkSession]
-    class UDFLibraryA()(implicit sparkToRegisterTo: Option[SparkSession]) extends OncePerSparkSession() {
-      override def register(implicit spark: Option[SparkSession]): Unit = {
+    class UDFLibraryA()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession() {
+      this.register(sparkToRegisterTo)
+      override protected def registerBody(implicit spark: SparkSession): Unit = {
         libraryAInitCounter += 1
       }
     }
 
-    class UDFLibraryB()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession()(sparkToRegisterTo) {
-      override protected def register(implicit spark: SparkSession): Unit = {
+    class UDFLibraryB()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession(sparkToRegisterTo) {
+      override protected def registerBody(implicit spark: SparkSession): Unit = {
         libraryBInitCounter += 1
       }
     }

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -49,27 +49,25 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
   }
 
   test("should return true if the library is registered successfully and false if not and if spark is not hasn't started"){
-    var libraryAInitCounter = 0
-    var results_1 = false
-    var results_2 = false
     class UDFLibrary()(implicit sparkToRegister: SparkSession) extends OncePerSparkSession(){
-      results_1 = this.register(sparkToRegister)
-      results_2 = this.register(sparkToRegister)
+
+      var libraryAInitCounter = 0
+      val results_1 = this.register(sparkToRegister)
+      val results_2 = this.register(sparkToRegister)
       override protected def registerBody(spark: SparkSession): Unit = {
-        libraryAInitCounter += 1
+        this.libraryAInitCounter += 1
       }
+
     }
 
-    new UDFLibrary()
-    assert(results_1 == true)
-    assert(results_2 == false)
+    val UdfLibrary = new UDFLibrary()
+    assert(UdfLibrary.results_1 == true)
+    assert(UdfLibrary.results_2 == false)
+    assert(UdfLibrary.libraryAInitCounter == 1)
   }
 
-  test("should return is registered successfully and false if not and if spark is not hasn't started") {
+  test("should return false if the library is registered successfully and false if provided that spark session has started") {
     var libraryAInitCounter = 0
-//    var results_1 = false
-//    var results_2 = false
-
     val anotherSpark: SparkSession =  mock[SparkSession]
     class UDFLibrary()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession(sparkToRegisterTo) {
       val results_1 = this.register(sparkToRegisterTo)
@@ -78,12 +76,13 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
       override protected def registerBody(spark: SparkSession): Unit = {
         libraryAInitCounter += 1
       }
+
     }
 
-//    new UDFLibrary()
-    val results = new UDFLibrary()(anotherSpark)
-    assert(results.results_1 == true)
-    assert(results.results_2 == false)
+    val library = new UDFLibrary()(anotherSpark)
+    assert(library.results_1 == false)
+    assert(library.results_2 == false)
+    assert(libraryAInitCounter == 1)
   }
 
 }

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -59,11 +59,6 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
   }
 
   test("should return false for result provided that spark session has started") {
-    /*
-    * It returns false because the constructor will actually register the library before the call for the register
-    * method on line 77.
-    * Up for discussion though.
-    */
 
     val anotherSpark: SparkSession =  mock[SparkSession]
     class UDFLibrary()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession(sparkToRegisterTo) {

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -27,7 +27,7 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
     var libraryBInitCounter = 0
 
     val anotherSpark: SparkSession =  mock[SparkSession]
-    class UDFLibraryA()(implicit sparkToRegisterTo: Option[SparkSession]) extends OncePerSparkSession()(sparkToRegisterTo) {
+    class UDFLibraryA()(implicit sparkToRegisterTo: Option[SparkSession]) extends OncePerSparkSession() {
       override def register(implicit spark: Option[SparkSession]): Unit = {
         libraryAInitCounter += 1
       }

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -48,4 +48,21 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
     assert(libraryBInitCounter == 2)
   }
 
+  test("should return true if the library is registered successfully and false if not"){
+    var libraryAInitCounter = 0
+    var results_1 = false
+    var results_2 = false
+    class UDFLibrary()(implicit sparkToRegister: SparkSession) extends OncePerSparkSession(){
+      results_1 = this.register(sparkToRegister)
+      results_2 = this.register(sparkToRegister)
+      override protected def registerBody(spark: SparkSession): Unit = {
+        libraryAInitCounter += 1
+      }
+    }
+
+    new UDFLibrary()
+    assert(results_1 == true)
+    assert(results_2 == false)
+  }
+
 }

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -62,13 +62,11 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
 
     val anotherSpark: SparkSession =  mock[SparkSession]
     class UDFLibrary()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession(sparkToRegisterTo) {
-      // Results will yield false because this will be second attempt of registering after the auto register has taken place
-      val results = this.register(sparkToRegisterTo)
       override protected def registerBody(spark: SparkSession): Unit = {}
     }
 
     val library = new UDFLibrary()
-    assert(!library.results)
+    assert(!library.register(spark))
     assert(library.register(anotherSpark))
   }
 

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -29,17 +29,16 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
     val anotherSpark: SparkSession =  mock[SparkSession]
     class UDFLibraryA()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession() {
       this.register(sparkToRegisterTo)
-      override protected def registerBody(implicit spark: SparkSession): Unit = {
+      override protected def registerBody(spark: SparkSession): Unit = {
         libraryAInitCounter += 1
       }
     }
 
     class UDFLibraryB()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession(sparkToRegisterTo) {
-      override protected def registerBody(implicit spark: SparkSession): Unit = {
+      override protected def registerBody(spark: SparkSession): Unit = {
         libraryBInitCounter += 1
       }
     }
-
 
     new UDFLibraryA()
     new UDFLibraryA()

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -66,7 +66,13 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
     assert(UdfLibrary.libraryAInitCounter == 1)
   }
 
-  test("should return false if the library is registered successfully and false if provided that spark session has started") {
+  test("should return false for both results if provided that spark session has started") {
+    /*
+    * It returns false because the constructor will actually register the library before the call for the register
+    * method on line 77.
+    * Up for discussion though.
+    */
+
     var libraryAInitCounter = 0
     val anotherSpark: SparkSession =  mock[SparkSession]
     class UDFLibrary()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession(sparkToRegisterTo) {

--- a/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
+++ b/spark-commons/src/test/scala/za/co/absa/spark/commons/OncePerSparkSessionTest.scala
@@ -27,8 +27,8 @@ class OncePerSparkSessionTest extends AnyFunSuite with MockitoSugar with SparkTe
     var libraryBInitCounter = 0
 
     val anotherSpark: SparkSession =  mock[SparkSession]
-    class UDFLibraryA()(implicit sparkToRegisterTo: SparkSession) extends OncePerSparkSession()(sparkToRegisterTo) {
-      override protected def register(implicit spark: SparkSession): Unit = {
+    class UDFLibraryA()(implicit sparkToRegisterTo: Option[SparkSession]) extends OncePerSparkSession()(sparkToRegisterTo) {
+      override def register(implicit spark: Option[SparkSession]): Unit = {
         libraryAInitCounter += 1
       }
     }


### PR DESCRIPTION
OncePerSpark

- Modified `OncePerSpark` class to be instantiable even when the spark session hasn't started.
- Changed the signature of the `register` method to return a `Boolean` for tracking if the `Library` was registered or not.
- Added the test for the `register` method. It assert the method to `true` if the `Library` was registered and `false` if not
