### PR TITLE
Make Spark-Commons releasable under new Maven central repository

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ ThisBuild / organization := "za.co.absa"
 
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.18"
-lazy val scala213 = "2.13.11"
+lazy val scala213 = "2.13.13"
 lazy val spark2   = "2.4.8"
 lazy val spark32   = "3.2.4"
 lazy val spark33   = "3.3.2"

--- a/project/build.properties
+++ b/project/build.properties
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 
-sbt.version=1.6.2
+sbt.version=1.11.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-addSbtPlugin("com.github.sbt"     % "sbt-ci-release"    % "1.5.10")
+addSbtPlugin("com.github.sbt"     % "sbt-ci-release"    % "1.11.2")
 
 addSbtPlugin("de.heikoseeberger"  % "sbt-header"        % "5.7.0")
 

--- a/publish.sbt
+++ b/publish.sbt
@@ -49,6 +49,18 @@ ThisBuild / developers := List(
     url   = url("https://github.com/AdrianOlosutean")
   ),
   Developer(
+    id    = "ABLL526",
+    name  = "Liam Leibrandt",
+    email = "liam.leibrandt@absa.africa",
+    url   = url("https://github.com/ABLL526")
+  ),
+  Developer(
+    id = "jakipatryk",
+    name = "Bartlomiej Baj",
+    email = "bartlomiej.baj@absa.africa",
+    url = url("https://github.com/jakipatryk")
+  ),
+  Developer(
     id    = "lsulak",
     name  = "Ladislav Sulak",
     email = "ladislav.sulak@absa.africa",


### PR DESCRIPTION
Make Spark-Commons releasable under new Maven central repository

Closes #118

Release Notes:
- Updated `sbt.version` to `1.11.5` for release.
- Updated Developers
- Updated `sbt-ci-release` to `1.11.2`
- Updated `scala213 = "2.13.13"`