### PR TITLE
comment out unsupported sbt configuration in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,17 +15,18 @@ updates:
       prefix: "chore"
       include: "scope"
 
-  - package-ecosystem: "sbt"
-    directory: "/"
-    target-branch: "master"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-    labels:
-      - "auto update"
-      - "dependencies"
-      - "no RN"
-    open-pull-requests-limit: 3
-    commit-message:
-      prefix: "chore"
-      include: "scope"
+  # Note: sbt is not supported by Dependabot yet
+  # - package-ecosystem: "sbt"
+  #   directory: "/"
+  #   target-branch: "master"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "sunday"
+  #   labels:
+  #     - "auto update"
+  #     - "dependencies"
+  #     - "no RN"
+  #   open-pull-requests-limit: 3
+  #   commit-message:
+  #     prefix: "chore"
+  #     include: "scope"


### PR DESCRIPTION
**Summary:**
This pull request makes a minor update to the `.github/dependabot.yml` configuration by commenting out the `sbt` package-ecosystem section, with a note that Dependabot does not yet support `sbt`. No other changes are included.

Release Notes:
- Commented out the `sbt` configuration in `.github/dependabot.yml` and added a note explaining that `sbt` is not supported by Dependabot yet.