### PR TITLE
feat: Adding RN Generator into the project.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!-- What problem does it solve or what feature does it add? -->
+## Overview
+
+<!-- Summarize the key changes for release notes. -->
+## Release Notes
+- TBD: 1st item of release notes
+- TBD: 2nd item of release notes
+
+<!-- Add attached issue that this PR solves. -->
+## Related
+Closes #issue_number

--- a/.github/workflows/check_pr_release_notes.yml
+++ b/.github/workflows/check_pr_release_notes.yml
@@ -1,0 +1,46 @@
+#
+# Copyright 2021 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Check PR Release Notes
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    branches: [ master ]
+
+concurrency:
+  group: release-notes-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-release-notes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.14'
+
+      - name: Check presence of release notes in PR description
+        uses: AbsaOSS/release-notes-presence-check@8e586b26a5e27f899ee8590a5d988fd4780a3dbf # v0.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          github-repository: ${{ github.repository }}
+          pr-number: ${{ github.event.number }}
+          title: "## [Rr]elease [Nn]otes"
+          skip-labels: 'no RN'
+          skip-placeholders: 'TBD'

--- a/.github/workflows/gh_release_draft.yml
+++ b/.github/workflows/gh_release_draft.yml
@@ -1,0 +1,122 @@
+#
+# Copyright 2021 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: GitHub Draft Release
+on:
+  workflow_dispatch:
+    inputs:
+      tag-name:
+        description: 'Name of git tag to be created, and then draft release created. Syntax: "v[0-9]+.[0-9]+.[0-9]+".'
+        required: true
+      from-tag-name:
+        description: >-
+          Name of the git tag from which to detect changes from.
+          Default value: latest tag. Syntax: "v[0-9]+.[0-9]+.[0-9]+".
+        required: false
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: read
+
+jobs:
+  release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.14'
+
+      - name: Check format of received target tag
+        id: check-version-tag
+        uses: AbsaOSS/version-tag-check@4145e48bf3f77a5afff2ec9afdd8afb6b53bce34 # v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          github-repository: ${{ github.repository }}
+          version-tag: ${{ github.event.inputs.tag-name }}
+
+      - name: Check format of received from tag
+        if: ${{ github.event.inputs.from-tag-name }}
+        id: check-version-from-tag
+        uses: AbsaOSS/version-tag-check@4145e48bf3f77a5afff2ec9afdd8afb6b53bce34 # v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          github-repository: ${{ github.repository }}
+          version-tag: ${{ github.event.inputs.from-tag-name }}
+          should-exist: true
+
+      - name: Create and push tag
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TAG_NAME: ${{ github.event.inputs.tag-name }}
+        with:
+          script: |
+            const tag = process.env.TAG_NAME;
+            const ref = `refs/tags/${tag}`;
+            const sha = context.sha;
+
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: ref,
+              sha: sha
+            });
+
+            console.log(`Tag created: ${tag}`);
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Release Notes
+        id: generate_release_notes
+        uses: AbsaOSS/generate-release-notes@26eca65fc504c088a7afd8b08545a738ad8b446b # v1.3.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release-notes-title: "## [Rr]elease [Nn]otes"
+          tag-name: ${{ github.event.inputs.tag-name }}
+          from-tag-name: ${{ github.event.inputs.from-tag-name }}
+          chapters: |
+            - { title: Breaking Changes 💥, label: breaking change, order: 10 }
+            - { title: Epics 🚀, label: epic, order: 20 }
+            - { title: New Features 🎉, label: enhancement, order: 30 }
+            - { title: Bugfixes 🛠, label: bug, order: 40 }
+            - { title: Documentation 📚, label: documentation, order: 50 }
+            - { title: Infrastructure ⚙️, label: infrastructure, order: 60 }
+            - { title: Refactoring ♻️, label: refactoring, order: 70 }
+            - { title: Spikes 💡, label: spike, order: 80 }
+            - { title: Entries to skip 🚫, labels: [duplicate, no RN], hidden: true, order: 99 }
+          warnings: true
+          print-empty-chapters: false
+          row-format-issue: '{type}: {number} _{title}_ by {developers} in {pull-requests}'
+          row-format-pr: '{number} _{title}_ by {developers}'
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ github.event.inputs.tag-name }}
+          body: ${{ steps.generate_release_notes.outputs.release-notes }}
+          tag_name: ${{ github.event.inputs.tag-name }}
+          draft: true
+          prerelease: false


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Overview
This pull request introduces new GitHub workflow automation and improves the pull request process by adding templates and automated checks related to release notes. The main changes focus on ensuring that release notes are consistently provided for each pull request and streamlining the process of drafting GitHub releases.

<!-- Summarize the key changes for release notes. -->
## Release Notes
- This PR adds a united way how to generate a GH draft having Release Notes with GH Action. It stores the generator workflow, release notes check workflow and PR template, that helps to not forget about additional release notes.
- Adds a `no RN` label to the project

<!-- Add attached issue that this PR solves. -->
## Related
Closes #137 